### PR TITLE
Allow non unique user id/group id

### DIFF
--- a/transmission.sh
+++ b/transmission.sh
@@ -66,8 +66,8 @@ done
 shift $(( OPTIND - 1 ))
 
 [[ "${TZ:-""}" ]] && timezone "$TZ"
-[[ "${USERID:-""}" =~ ^[0-9]+$ ]] && usermod -u $USERID debian-transmission
-[[ "${GROUPID:-""}" =~ ^[0-9]+$ ]] && groupmod -g $GROUPID debian-transmission
+[[ "${USERID:-""}" =~ ^[0-9]+$ ]] && usermod -u $USERID -o debian-transmission
+[[ "${GROUPID:-""}" =~ ^[0-9]+$ ]] && groupmod -g $GROUPID -o debian-transmission
 
 [[ -d $dir/downloads ]] || mkdir -p $dir/downloads
 [[ -d $dir/incomplete ]] || mkdir -p $dir/incomplete


### PR DESCRIPTION
This commit allows the user UID and group UID of ``debian-transmission`` to be non-unique. Thus it is possible to change ``debian-transmission`` UID and GID to ``root``'s ones (or www-data, etc.).