### PR TITLE
Add the ability to set arbitrary options via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,17 @@ OR set local storage:
 
     The 'command' (if provided and valid) will be run instead of transmission
 
-ENVIROMENT VARIABLES (only available with `docker run`)
+ENVIRONMENT VARIABLES (only available with `docker run`)
 
- * `TRUSER` - Set the username for transmission auth (default 'admin')
- * `TRPASSWD` - Set the password for transmission auth (default 'admin')
+ * `TR_USER` - Set the username for transmission auth (default 'admin')
+ * `TR_PASSWD` - Set the password for transmission auth (default 'admin')
  * `TZ` - As above, configure the zoneinfo timezone, IE `EST5EDT`
  * `USERID` - Set the UID for the app user
  * `GROUPID` - Set the GID for the app user
+
+Other environment variables beginning with `TR_` will edit the configuration file
+accordingly:
+ * `TR_MAX_PEERS_GLOBAL=400` will translate to `"max-peers-global": 400,`
 
 ## Examples
 


### PR DESCRIPTION
* Map env vars beginning by `TR_` to the config file
* Rename `TRUSER` and `TRPASSWD` to `TR_USER` and `TR_PASSWD` respectively
for consistancy but keep supporting old names for backward compatibility
* Remove hardcoded options since they can now be passed via env vars