### PR TITLE
Respect authentication settings that are set within settings.json

### DIFF
--- a/transmission.sh
+++ b/transmission.sh
@@ -99,8 +99,7 @@ else
     chown debian-transmission. $dir/info/blocklists/bt_level1
     exec su -l debian-transmission -s /bin/bash -c "exec transmission-daemon \
                 --config-dir $dir/info --blocklist --encryption-preferred \
-                --auth --dht --foreground --log-error -e /dev/stdout \
+                --dht --foreground --log-error -e /dev/stdout \
                 --download-dir $dir/downloads --incomplete-dir $dir/incomplete \
-                --username '${TRUSER:-admin}' --password '${TRPASSWD:-admin}' \
                 --no-portmap --allowed \\* 2>&1"
 fi


### PR DESCRIPTION
This may/may not be useful (and might need some more work for compatibility), but it would be nice to respect the settings set in the auth file for user authentication. For my specific purpose, I do not wish to have auth, and disabling it is impossible AFAIK without these modifications. 

My suggestion is to have an env flag that could toggle auth entirely, rather than forcing it always. 