### PR TITLE
Fix -n (No auth) option

### DIFF
--- a/transmission.sh
+++ b/transmission.sh
@@ -105,9 +105,13 @@ else
                     gzip -cd >$dir/info/blocklists/bt_level1
         chown debian-transmission. $dir/info/blocklists/bt_level1
     fi
+    if [ -n "$NOAUTH" ]; then
+        AUTH_OPT="--no-auth"
+    else
+        AUTH_OPT="--auth --username '${TRUSER:-admin}' --password '${TRPASSWD:-admin}'"
+    fi
     exec su -l debian-transmission -s /bin/bash -c "exec transmission-daemon \
                 --config-dir $dir/info --blocklist --encryption-preferred \
                 --dht --allowed \\* --foreground --log-info --no-portmap \
-                $([[ ${NOAUTH:-""} ]] || echo '--auth --username \
-                '"${TRUSER:-admin}"' --password '"${TRPASSWD:-admin}") 2>&1"
+                $AUTH_OPT 2>&1"
 fi


### PR DESCRIPTION
Hi,

I was trying to use the -n option end was still encountering 401 errors.

It seems that the default configuration of transmission, when no
auth-related argument is provided, is to enable authentification.

Therefore the --no-auth option must be provided to actually disable
authentification.

Bertrand