### PR TITLE
Don't force --dht flag

### DIFF
--- a/transmission.sh
+++ b/transmission.sh
@@ -107,7 +107,7 @@ else
     fi
     exec su -l debian-transmission -s /bin/bash -c "exec transmission-daemon \
                 --config-dir $dir/info --blocklist --encryption-preferred \
-                --dht --allowed \\* --foreground --log-info --no-portmap \
+                --allowed \\* --foreground --log-info --no-portmap \
                 $([[ ${NOAUTH:-""} ]] && echo '--no-auth' || echo "--auth \
                 --username ${TRUSER:-admin} --password ${TRPASSWD:-admin}")"
 fi


### PR DESCRIPTION
Is it necessary to force the dht flag on?

It's possible to change this option in the settings.json, but  in a dynamic environment my config is getting overwritten with dht enabled.

This change would allow users to choose by specifying in their settings.json whether to enable dht.