### PR TITLE
Make encryption configurable

### DIFF
--- a/transmission.sh
+++ b/transmission.sh
@@ -106,7 +106,7 @@ else
         chown debian-transmission. $dir/info/blocklists/bt_level1
     fi
     exec su -l debian-transmission -s /bin/bash -c "exec transmission-daemon \
-                --config-dir $dir/info --blocklist --encryption-preferred \
+                --config-dir $dir/info --blocklist \
                 --allowed \\* --foreground --log-info --no-portmap \
                 $([[ ${NOAUTH:-""} ]] && echo '--no-auth' || echo "--auth \
                 --username ${TRUSER:-admin} --password ${TRPASSWD:-admin}")"


### PR DESCRIPTION
So that the `encryption` parameter can be set using the `TR_ENCRYPTION` environment variable. It can be `0` (for "prefer unencrypted"), `1` (for "prefer encrypted", default) or `2` (for "require encrypted") as described in [the Transmission wiki](https://github.com/transmission/transmission/wiki/Editing-Configuration-Files).

This PR won't break existing setups, since `--encryption-preferred` (which is `"encryption": 1`) is the default anyway ¯\\\_(ツ)\_/¯