### PR TITLE
fix trailing comma in settings.json

### DIFF
--- a/transmission.sh
+++ b/transmission.sh
@@ -79,6 +79,8 @@ for env in $(printenv | grep '^TR_'); do
         sed -i "/^}/i\    \"$name\": $val" $dir/info/settings.json
     fi
 done
+# json file above has trailing comma. Fix with sed
+sed -i -zr 's/,([^,]*$)/\1/' $dir/info/settings.json
 
 watchdir=$(awk -F'=' '/"watch-dir"/ {print $2}' $dir/info/settings.json |
             sed 's/[,"]//g')


### PR DESCRIPTION
I noticed that when environment variables are written to `settings.json`, the last line has a trailing comma, preventing Transmission from starting up. This sed call should fix that.