### PR TITLE
Fix typo on Downloads and Incomplete paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ OR set local storage (see *Complex configuration* below):
                 -d dperson/transmission
 
 **NOTE**: The configuration is in `/var/lib/transmission-daemon/info`, downloads
-are in `/var/lib/transmission-daemon/downloads`, and partial downloads are in
-`/var/lib/transmission-daemon/incomplete`.
+are in `/var/lib/transmission-daemon/Downloads`, and partial downloads are in
+`/var/lib/transmission-daemon/Incomplete`.
 
 ## Configuration
 


### PR DESCRIPTION
Downloads and Incomplete paths start with uppercase, so you must map it using uppercase to get it done correctly.